### PR TITLE
Fix quality and speed change on mobile

### DIFF
--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -22,6 +22,13 @@ export default {
       snackbar: false,
       player: null,
       options: {
+      html5: {
+          hls: {
+            overrideNative: true
+          },
+          nativeAudioTracks: false,
+          nativeVideoTracks: false,
+        }
         autoplay: true,
         controls: true,
         controlBar: { pictureInPictureToggle: false },


### PR DESCRIPTION
These options should be added because native implementations in mobile browsers are ignoring videojs controls.